### PR TITLE
Allow multiple confidence intervals

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     graphics,
     stats,
     glue
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 Suggests: 
     knitr,
     rmarkdown,

--- a/R/tidy-mcmc-list.R
+++ b/R/tidy-mcmc-list.R
@@ -33,12 +33,18 @@
 #'      chain = TRUE,
 #'      colnames=c("alpha"))
 #' # can provide two levels of confidence:
-#' tidy(line, conf_level = c(0.95, 50))
+#' tidy(line, conf_level = c(0.95, 0.50))
+#' tidy(line, conf_level = c(0.95))
+#' tidy(line, conf_level = c(0.89, 0.25))
 tidy.mcmc.list <- function(x,
                            conf_level = c(0.95),
                            chain = FALSE,
                            colnames = NULL,
                            ...){
+
+    if (any(conf_level >= 1)) {
+        stop("Confidence level needs to be below 1, it is", conf_level)
+    }
 
     # set credible interval quantiles to use
 

--- a/R/tidy-mcmc-list.R
+++ b/R/tidy-mcmc-list.R
@@ -8,7 +8,8 @@
 #'
 #' @param x object of class "mcmc.list", as you would find with fitting a model
 #'   using `jags.model()`, and `coda.samples`.
-#' @param conf_level level of the credible interval to be calculated
+#' @param conf_level level of the credible interval to be calculated.
+#'   Can be multiple values.
 #' @param chain whether or not to summarise each parameter for each chain
 #' @param colnames which parameters we want from `mcmc_object`, if `NULL` then all
 #'   columns get selected
@@ -31,6 +32,8 @@
 #' tidy(line,
 #'      chain = TRUE,
 #'      colnames=c("alpha"))
+#' # can provide two levels of confidence:
+#' tidy(line, conf_level = c(0.95, 50))
 tidy.mcmc.list <- function(x,
                            conf_level = c(0.95),
                            chain = FALSE,
@@ -53,7 +56,16 @@ tidy.mcmc.list <- function(x,
         my_by <- c(my_by, "chain")
     }
 
-    if(length(conf_level)==2){
+    if (length(conf_level) > 2 ) {
+        stop("conf_level is ",
+             conf_level,
+             " it must either be length 1 or 2 and it is length",
+             length(conf_level)
+             )
+    }
+
+    if (length(conf_level) == 2) {
+
     x_dt_s <- x_dt[ , list(mean = mean(value),
                            sd = stats::sd(value),
                            q1 = stats::quantile(value, q[1]),
@@ -68,7 +80,7 @@ tidy.mcmc.list <- function(x,
                          new = sprintf("%2.1f%%", q * 100))
     return(x_dt_s)
 
-    } else if(length(conf_level)==1){
+    } else if (length(conf_level) == 1) {
     x_dt_s <- x_dt[ , list(mean = mean(value),
                            sd = stats::sd(value),
                            q1 = stats::quantile(value, q[1]),
@@ -82,8 +94,6 @@ tidy.mcmc.list <- function(x,
 
     return(x_dt_s)
 
-    } else{
-        stop("conf_level must either be length 1 or 2")
     }
 }
 

--- a/man/example_jags_model.Rd
+++ b/man/example_jags_model.Rd
@@ -4,7 +4,9 @@
 \name{example_jags_model}
 \alias{example_jags_model}
 \title{Example JAGS Model}
-\format{An object of class \code{jags} of length 8.}
+\format{
+An object of class \code{jags} of length 8.
+}
 \usage{
 data(example_jags_model)
 }

--- a/man/example_stan_model.Rd
+++ b/man/example_stan_model.Rd
@@ -4,7 +4,9 @@
 \name{example_stan_model}
 \alias{example_stan_model}
 \title{Example STAN Model}
-\format{An object of class \code{stanfit} of dimension 5 x 4 x 3.}
+\format{
+An object of class \code{stanfit} of dimension 5 x 4 x 3.
+}
 \usage{
 data(example_stan_model)
 }

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -12,6 +12,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{generics}{\code{\link[generics]{tidy}}, \code{\link[generics]{glance}}}
+  \item{generics}{\code{\link[generics]{glance}}, \code{\link[generics]{tidy}}}
 }}
 

--- a/man/tidy.mcmc.list.Rd
+++ b/man/tidy.mcmc.list.Rd
@@ -40,7 +40,9 @@ tidy(line,
      chain = TRUE,
      colnames=c("alpha"))
 # can provide two levels of confidence:
-tidy(line, conf_level = c(0.95, 50))
+tidy(line, conf_level = c(0.95, 0.50))
+tidy(line, conf_level = c(0.95))
+tidy(line, conf_level = c(0.89, 0.25))
 }
 \author{
 Sam Clifford, \email{sj.clifford@gmail.com}

--- a/man/tidy.mcmc.list.Rd
+++ b/man/tidy.mcmc.list.Rd
@@ -4,14 +4,14 @@
 \alias{tidy.mcmc.list}
 \title{Return a tidy data summary of an MCMC object}
 \usage{
-\method{tidy}{mcmc.list}(x, conf_level = 0.95, chain = FALSE,
-  colnames = NULL, ...)
+\method{tidy}{mcmc.list}(x, conf_level = c(0.95), chain = FALSE, colnames = NULL, ...)
 }
 \arguments{
 \item{x}{object of class "mcmc.list", as you would find with fitting a model
 using \code{jags.model()}, and \code{coda.samples}.}
 
-\item{conf_level}{level of the credible interval to be calculated}
+\item{conf_level}{level of the credible interval to be calculated.
+Can be multiple values.}
 
 \item{chain}{whether or not to summarise each parameter for each chain}
 
@@ -39,6 +39,8 @@ tidy(line)
 tidy(line,
      chain = TRUE,
      colnames=c("alpha"))
+# can provide two levels of confidence:
+tidy(line, conf_level = c(0.95, 50))
 }
 \author{
 Sam Clifford, \email{sj.clifford@gmail.com}

--- a/tests/testthat/test-tidy.R
+++ b/tests/testthat/test-tidy.R
@@ -52,3 +52,10 @@ test_that("tidy colnames and chain options work", {
     expect_equal(ncol(tidy(line, colnames = "sigma", chain = TRUE)), 7)
 })
 
+test_that("tidy fails when conf_level is three numbers", {
+    expect_error(tidy(line, conf_level = c(0.95, 0.50, 0.25)))
+})
+
+test_that("tidy fails when conf_level is greater than 1", {
+    expect_error(tidy(line, conf_level = c(0.95, 50)))
+})


### PR DESCRIPTION
Added the ability to provide a vector of length 2 to the `conf_level` argument in `tidy.mcmc.list`, for example, `c(0.95, 0.50)`, to produce the 95% and 50% interval. Useful when it's not necessarily appropriate to report the mean or median.